### PR TITLE
refactor: add departments entity

### DIFF
--- a/backend/__tests__/auth.test.ts
+++ b/backend/__tests__/auth.test.ts
@@ -18,11 +18,12 @@ jest.mock('../src/config/database', () => {
   const { User } = require('../src/models/User');
   const { Feedback } = require('../src/models/Feedback');
   const { Suggestion } = require('../src/models/Suggestion');
+  const { Department } = require('../src/models/Department');
   const ds = new DataSource({
     type: 'sqlite',
     database: ':memory:',
     synchronize: true,
-    entities: [User, Feedback, Suggestion],
+    entities: [User, Feedback, Suggestion, Department],
   });
   return { AppDataSource: ds };
 });

--- a/backend/__tests__/feedbackRoutes.test.ts
+++ b/backend/__tests__/feedbackRoutes.test.ts
@@ -1,4 +1,6 @@
 process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/testdb';
+process.env.JWT_SECRET = 'testsecret';
+process.env.JWT_EXPIRES_IN = '1d';
 import request from 'supertest';
 import express from 'express';
 import feedbackRoutes from '../src/routes/feedback';
@@ -25,8 +27,8 @@ describe('POST /api/feedback', () => {
   it('creates feedback when valid', async () => {
     const res = await request(app)
       .post('/api/feedback')
-      .send({ department: 'Recepção', rating: 'Bom' });
+      .send({ departmentId: 'recepcao', rating: 'Bom' });
     expect(res.status).toBe(201);
-    expect(res.body).toMatchObject({ department: 'Recepção', rating: 'Bom' });
+    expect(res.body).toMatchObject({ department: { id: 'recepcao' }, rating: 'Bom' });
   });
 });

--- a/backend/docs/api.md
+++ b/backend/docs/api.md
@@ -13,8 +13,8 @@
 ## Feedback
 - **POST** `/api/feedback` — Criar feedback
   - Header: `Authorization: Bearer <token>`
-  - Body: `{ "department": "...", "rating": "Excelente|Bom|Regular|Ruim" }`
-  - Resposta: `{ "id": "...", "department": "...", "rating": "...", ... }`
+  - Body: `{ "departmentId": "...", "rating": "Excelente|Bom|Regular|Ruim" }`
+  - Resposta: `{ "id": "...", "department": { "id": "...", "name": "..." }, "rating": "...", ... }`
 
 - **GET** `/api/feedback` — Listar feedbacks (admin)
   - Header: `Authorization: Bearer <token_admin>`

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -3,13 +3,14 @@ import { DataSource } from 'typeorm';
 import { User } from '../models/User';
 import { Feedback } from '../models/Feedback';
 import { Suggestion } from '../models/Suggestion';
+import { Department } from '../models/Department';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
   url: process.env.DATABASE_URL, // conexão completa
   synchronize: true,
   logging: false,
-  entities: [User, Feedback, Suggestion],
+  entities: [User, Feedback, Suggestion, Department],
   ssl: {
     rejectUnauthorized: false, // necessário no Render
   },

--- a/backend/src/controllers/FeedbackController.ts
+++ b/backend/src/controllers/FeedbackController.ts
@@ -6,18 +6,18 @@ import logger from '../config/logger';
 export class FeedbackController {
   async create(req: Request, res: Response) {
     try {
-      const { department, rating, suggestion, recomendacao } = req.body;
-      if (!department || !rating) {
+      const { departmentId, rating, suggestion, recomendacao } = req.body;
+      if (!departmentId || !rating) {
         return res.status(400).json({ error: 'Departamento e avaliação são obrigatórios.' });
       }
       const userId = req.user?.id;
 
-      logger.info('Recebendo novo feedback', { department, rating, userId, recomendacao });
+      logger.info('Recebendo novo feedback', { departmentId, rating, userId, recomendacao });
 
       const feedbackRepository = AppDataSource.getRepository(Feedback);
 
       const feedbackData: any = {
-        department,
+        department: { id: departmentId },
         rating,
       };
       if (userId) {
@@ -61,15 +61,17 @@ export class FeedbackController {
       let query = feedbackRepository
         .createQueryBuilder('feedback')
         .leftJoinAndSelect('feedback.user', 'user')
+        .leftJoinAndSelect('feedback.department', 'department')
         .select([
           'feedback.id',
-          'feedback.department',
           'feedback.rating',
           'feedback.createdAt',
           'feedback.suggestion',
           'feedback.recomendacao',
           'user.id',
           'user.name',
+          'department.id',
+          'department.name',
         ]);
 
       if (month && year) {

--- a/backend/src/migrations/1750000000000-addDepartments.ts
+++ b/backend/src/migrations/1750000000000-addDepartments.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDepartmentsTable1750000000000 implements MigrationInterface {
+    name = 'AddDepartmentsTable1750000000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+        await queryRunner.query(`CREATE TABLE "departments" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying NOT NULL, CONSTRAINT "UQ_departments_name" UNIQUE ("name"), CONSTRAINT "PK_departments_id" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "feedbacks" ADD "department_id" uuid`);
+        await queryRunner.query(`CREATE INDEX "IDX_feedback_department_id" ON "feedbacks" ("department_id")`);
+        await queryRunner.query(`ALTER TABLE "feedbacks" ADD CONSTRAINT "FK_feedback_department" FOREIGN KEY ("department_id") REFERENCES "departments"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`INSERT INTO departments (name) SELECT DISTINCT department FROM feedbacks WHERE department IS NOT NULL`);
+        await queryRunner.query(`UPDATE feedbacks f SET department_id = d.id FROM departments d WHERE f.department = d.name`);
+        await queryRunner.query(`ALTER TABLE "feedbacks" DROP COLUMN "department"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "feedbacks" ADD "department" character varying`);
+        await queryRunner.query(`UPDATE feedbacks f SET department = d.name FROM departments d WHERE f.department_id = d.id`);
+        await queryRunner.query(`ALTER TABLE "feedbacks" DROP CONSTRAINT "FK_feedback_department"`);
+        await queryRunner.query(`DROP INDEX "IDX_feedback_department_id"`);
+        await queryRunner.query(`ALTER TABLE "feedbacks" DROP COLUMN "department_id"`);
+        await queryRunner.query(`DROP TABLE "departments"`);
+    }
+}

--- a/backend/src/models/Department.ts
+++ b/backend/src/models/Department.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('departments')
+export class Department {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  name!: string;
+}

--- a/backend/src/models/Feedback.ts
+++ b/backend/src/models/Feedback.ts
@@ -1,5 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn, Index } from 'typeorm';
 import { User } from './User';
+import { Department } from './Department';
 
 export type Rating = 'Excelente' | 'Bom' | 'Regular' | 'Ruim';
 
@@ -10,9 +11,10 @@ export class Feedback {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  @Column()
+  @ManyToOne(() => Department, { eager: true })
+  @JoinColumn({ name: 'department_id' })
   @Index()
-  department!: string;
+  department!: Department;
 
   @Column({
     type: process.env.NODE_ENV === 'test' ? 'text' : 'enum',

--- a/backend/src/routes/exportExcel.ts
+++ b/backend/src/routes/exportExcel.ts
@@ -34,12 +34,12 @@ router.get('/export/excel', authMiddleware, adminMiddleware, async (req, res) =>
   sheet.getCell(`A${row}`).value = 'Feedbacks por Departamento';
   sheet.getCell(`A${row}`).font = { bold: true };
   row++;
-  const departamentos = Array.from(new Set(feedbacks.map(f => f.department)));
+  const departamentos = Array.from(new Set(feedbacks.map(f => f.department.name)));
   for (const dep of departamentos) {
     sheet.getCell(`A${row}`).value = dep;
     sheet.getCell(`A${row}`).font = { bold: true, color: { argb: 'FF19984B' } };
     row++;
-    feedbacks.filter(f => f.department === dep).forEach(fb => {
+    feedbacks.filter(f => f.department.name === dep).forEach(fb => {
       sheet.getCell(`A${row}`).value = new Date(fb.createdAt).toLocaleString('pt-BR');
       sheet.getCell(`B${row}`).value = fb.rating;
       row++;

--- a/backend/src/routes/exportPdf.ts
+++ b/backend/src/routes/exportPdf.ts
@@ -54,7 +54,7 @@ router.get('/export/pdf', authMiddleware, adminMiddleware, async (req, res) => {
     // Data
     doc.fillColor('#222').fontSize(11).text(new Date(fb.createdAt).toLocaleString('pt-BR'), startX + 8, y + 6, { width: colWidths[0] - 8 });
     // Departamento
-    doc.text(fb.department, startX + colWidths[0] + 8, y + 6, { width: colWidths[1] - 8 });
+    doc.text(fb.department.name, startX + colWidths[0] + 8, y + 6, { width: colWidths[1] - 8 });
     // Badge Avaliação
     const badgeColor = getBadgeColor(fb.rating);
     doc.roundedRect(startX + colWidths[0] + colWidths[1] + 8, y + 6, 60, 14, 4).fillAndStroke(badgeColor, badgeColor);

--- a/backend/src/routes/feedback.ts
+++ b/backend/src/routes/feedback.ts
@@ -9,7 +9,7 @@ const feedbackController = new FeedbackController();
 router.post(
   '/',
   [
-    body('department').isString().trim().escape().notEmpty().withMessage('Departamento é obrigatório'),
+    body('departmentId').isString().trim().escape().notEmpty().withMessage('Departamento é obrigatório'),
     body('rating').isString().trim().escape().notEmpty().withMessage('Avaliação é obrigatória'),
     body('suggestion').optional().isString().trim(),
     body('recomendacao')

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 export default {
   testEnvironment: "node",
   transform: {
-    "^.+\.tsx?$": ["ts-jest",{}],
+    "^.+\.tsx?$": ["ts-jest", { tsconfig: "backend/tsconfig.json" }],
   },
   setupFiles: ['jest-localstorage-mock'],
 };


### PR DESCRIPTION
## Summary
- add `Department` entity and reference it from `Feedback`
- migrate existing feedbacks to use department relation
- document new `departmentId` field for feedback API

## Testing
- `npm test`
- `npm run lint` *(fails: no-undef and no-unused-vars in frontend files)*

------
https://chatgpt.com/codex/tasks/task_e_68befc75ecb88330a93abcee1f12f429