### PR TITLE
docs: unify database env configuration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+PORT=3001
+DATABASE_URL=postgres://usuario:senha@localhost:5432/scmg
+JWT_SECRET=sua_chave_secreta
+JWT_EXPIRES_IN=1d

--- a/backend/README.md
+++ b/backend/README.md
@@ -20,11 +20,7 @@ Crie um arquivo `.env` baseado em `.env.example`:
 
 ```
 PORT=3001
-DB_HOST=localhost
-DB_PORT=5432
-DB_USER=postgres
-DB_PASS=sua_senha
-DB_NAME=scmg
+DATABASE_URL=postgres://usuario:senha@localhost:5432/scmg
 JWT_SECRET=sua_chave_secreta
 JWT_EXPIRES_IN=1d
 ```


### PR DESCRIPTION
## Summary
- use DATABASE_URL as single database connection variable
- add backend .env.example

## Testing
- `npm test` *(fails: Property 'user' does not exist on type 'Request')*

------
https://chatgpt.com/codex/tasks/task_e_68befc7b261c8330aa38b87725e00311