### PR TITLE
Remove token logging from API service

### DIFF
--- a/frontend/src/contexts/FeedBackContext.tsx
+++ b/frontend/src/contexts/FeedBackContext.tsx
@@ -32,7 +32,7 @@ export const FeedbackProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const fetchFeedbacks = async () => {
     const token = localStorage.getItem('token');
     if (!token) {
-      console.warn('Token não encontrado. Ignorando fetch de feedbacks.');
+      console.warn('Credenciais ausentes. Ignorando fetch de feedbacks.');
       return;
     }
     setLoading(true);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,10 +1,7 @@
 function getToken() {
     const token = localStorage.getItem('token') || '';
     if (!token) {
-        console.warn('Token ausente no localStorage!');
-    }
-    else {
-        console.info('Token enviado:', token);
+        console.warn('Credenciais de autenticação ausentes.');
     }
     return token;
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -11,9 +11,7 @@ export interface FeedbacksResponse {
 function getToken() {
   const token = localStorage.getItem('token') || '';
   if (!token) {
-    console.warn('Token ausente no localStorage!');
-  } else {
-    console.info('Token enviado:', token);
+    console.warn('Credenciais de autenticação ausentes.');
   }
   return token;
 }

--- a/src/contexts/FeedBackContext.tsx
+++ b/src/contexts/FeedBackContext.tsx
@@ -32,7 +32,7 @@ export const FeedbackProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const fetchFeedbacks = async () => {
     const token = localStorage.getItem('token');
     if (!token) {
-      console.warn('Token não encontrado. Ignorando fetch de feedbacks.');
+      console.warn('Credenciais ausentes. Ignorando fetch de feedbacks.');
       return;
     }
     setLoading(true);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -11,9 +11,7 @@ export interface FeedbacksResponse {
 function getToken() {
   const token = localStorage.getItem('token') || '';
   if (!token) {
-    console.warn('Token ausente no localStorage!');
-  } else {
-    console.info('Token enviado:', token);
+    console.warn('Credenciais de autenticação ausentes.');
   }
   return token;
 }


### PR DESCRIPTION
## Summary
- remove token value console logs in API service
- use generic warning for missing credentials
- adjust context warnings to avoid token references

## Testing
- `npm test`
- `npm run lint` *(fails: localStorage/fetch globals and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bf04563f3883308e2abfc232b267aa