### PR TITLE
feat: configure allowed origins via env

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,4 @@ PORT=3001
 DATABASE_URL=postgres://usuario:senha@localhost:5432/scmg
 JWT_SECRET=sua_chave_secreta
 JWT_EXPIRES_IN=1d
+ALLOWED_ORIGINS=https://scmg-feedback.onrender.com,http://localhost:3000

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,12 +12,17 @@ import exportPdfRoutes from './routes/exportPdf';
 import exportExcelRoutes from './routes/exportExcel';
 
 const app = express();
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map(origin => origin.trim()).filter(Boolean)
+  : [];
 
 app.use(cors({
-  origin: [
-    'https://scmg-feedback.onrender.com',
-    'http://localhost:3000'
-  ],
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      return callback(null, true);
+    }
+    return callback(new Error('Not allowed by CORS'));
+  },
   credentials: true,
 }));
 app.use(express.json());


### PR DESCRIPTION
## Summary
- add `ALLOWED_ORIGINS` to backend env example
- read allowed origins from env in app and default to none when undefined

## Testing
- `npm test`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf046d6cb8833093381321566e2385