### PR TITLE
refactor: use express-validator ESM imports

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -35,7 +35,6 @@
         "@testing-library/react": "^16.3.0",
         "@types/exceljs": "^0.5.3",
         "@types/express-rate-limit": "^5.1.3",
-        "@types/express-validator": "^2.20.33",
         "@types/jest": "^29.5.14",
         "@types/pdfkit": "^0.13.9",
         "@types/react": "^19.1.8",
@@ -2676,16 +2675,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
-      }
-    },
-    "node_modules/@types/express-validator": {
-      "version": "2.20.33",
-      "resolved": "https://registry.npmjs.org/@types/express-validator/-/express-validator-2.20.33.tgz",
-      "integrity": "sha512-dAlxnuNhKkM/Xq2148NySrnutOSeK8Xk6rpDdDrNT5akAKqFbtLmMKENaMYYh4xWcSqtSWc5l+TLxnZosa9p/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*"
       }
     },
     "node_modules/@types/http-errors": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,7 +44,6 @@
     "@testing-library/react": "^16.3.0",
     "@types/exceljs": "^0.5.3",
     "@types/express-rate-limit": "^5.1.3",
-    "@types/express-validator": "^2.20.33",
     "@types/jest": "^29.5.14",
     "@types/pdfkit": "^0.13.9",
     "@types/react": "^19.1.8",

--- a/backend/src/routes/feedback.ts
+++ b/backend/src/routes/feedback.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { FeedbackController } from '../controllers/FeedbackController';
 import { authMiddleware, adminMiddleware } from '../middlewares/auth';
-const { body } = require('express-validator');
+import { body } from 'express-validator';
 
 const router = Router();
 const feedbackController = new FeedbackController();

--- a/backend/src/routes/suggestion.ts
+++ b/backend/src/routes/suggestion.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { SuggestionController } from '../controllers/SuggestionController';
 import { authMiddleware, adminMiddleware } from '../middlewares/auth';
-const { body } = require('express-validator');
+import { body } from 'express-validator';
 
 const router = Router();
 const suggestionController = new SuggestionController();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,10 +7,6 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "removeComments": true,
-    "typeRoots": [
-      "./node_modules/@types",
-      "./@types"
-    ],
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
## Summary
- replace CommonJS `require` with `import { body }` for express-validator in feedback and suggestion routes
- remove legacy @types package and typeRoots so TypeScript uses package-provided declarations

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` (backend)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0477aa448330a20e682befa918f8