### PR TITLE
feat(frontend): move department constants to frontend

### DIFF
--- a/frontend/src/components/AvaliacaoPage.tsx
+++ b/frontend/src/components/AvaliacaoPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams, Navigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useFeedback } from '../contexts/FeedBackContext';
-import { departments, Department } from '../../../backend/src/constants/department';
+import { departments, Department } from '../constants/department';
 import otimoSvg from '../assets/otimo.svg.svg';
 import bomSvg from '../assets/bom.svg.svg';
 import regularSvg from '../assets/regular.svg.svg';

--- a/frontend/src/constants/department.ts
+++ b/frontend/src/constants/department.ts
@@ -1,7 +1,9 @@
-export const departments = [
+export type Department = { id: string; name: string };
+
+export const departments: Department[] = [
   { id: 'recepcao', name: 'Recepção' },
   { id: 'enfermagem', name: 'Enfermagem' },
   { id: 'medicos', name: 'Médicos' },
   { id: 'limpeza', name: 'Limpeza' },
   { id: 'alimentacao', name: 'Alimentação' }
-]; 
+];

--- a/frontend/src/constants/departments.js
+++ b/frontend/src/constants/departments.js
@@ -1,7 +1,0 @@
-export const departments = [
-    { id: 'recepcao', name: 'Recepção' },
-    { id: 'enfermagem', name: 'Enfermagem' },
-    { id: 'medicos', name: 'Médicos' },
-    { id: 'limpeza', name: 'Limpeza' },
-    { id: 'alimentacao', name: 'Alimentação' }
-];

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 import { useFeedback } from '../contexts/FeedBackContext';
-import { departments } from '../../../backend/src/constants/department';
+import { departments } from '../constants/department';
 import * as ExcelJS from 'exceljs';
 import Papa from 'papaparse';
 import jsPDF from 'jspdf';

--- a/frontend/src/pages/AvaliacaoPage.tsx
+++ b/frontend/src/pages/AvaliacaoPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useParams, Navigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useFeedback } from '../contexts/FeedBackContext';
-import { departments } from '../constants/departments';
+import { departments, Department } from '../constants/department';
 import otimoSvg from '../assets/otimo.svg.svg';
 import bomSvg from '../assets/bom.svg.svg';
 import regularSvg from '../assets/regular.svg.svg';
@@ -110,8 +110,8 @@ const AvaliacaoPage = () => {
   const [clickedRating, setClickedRating] = useState<Rating | null>(null);
   const [dots, setDots] = useState('');
 
-  const currentDepartment = departments.find((d: any) => d.id === departmentId);
-  const currentIndex = departments.findIndex((d: any) => d.id === departmentId);
+  const currentDepartment = departments.find((d: Department) => d.id === departmentId);
+  const currentIndex = departments.findIndex((d: Department) => d.id === departmentId);
   const nextDepartment = departments[currentIndex + 1];
 
   useEffect(() => {

--- a/frontend/src/pages/FeedbacksDetalhados.tsx
+++ b/frontend/src/pages/FeedbacksDetalhados.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { useFeedback } from '../contexts/FeedBackContext';
-import { departments } from '../../../backend/src/constants/department';
+import { departments } from '../constants/department';
 import { useNavigate } from 'react-router-dom';
 
 const Container = styled.div`


### PR DESCRIPTION
## Summary
- create `frontend/src/constants/department.ts` with department definitions
- update front-end pages to import from new constants instead of backend
- remove obsolete duplicated constants

## Testing
- `npm test`
- `npm run lint` *(fails: 'localStorage' is not defined and other lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68bf04b87e5883308fb6ed16e941acc2