### PR TITLE
chore: configure jest for frontend tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,10 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 export default {
-  testEnvironment: "node",
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
   transform: {
-    "^.+\.tsx?$": ["ts-jest", { tsconfig: "backend/tsconfig.json" }],
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: './tsconfig.jest.json' }],
   },
   setupFiles: ['jest-localstorage-mock'],
+  testPathIgnorePatterns: ['<rootDir>/backend/'],
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "jest --coverage --passWithNoTests --testPathIgnorePatterns=backend --testPathIgnorePatterns=frontend"
+    "test": "jest --coverage --passWithNoTests --testPathIgnorePatterns=backend"
   },
   "dependencies": {
     "exceljs": "^4.4.0",

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "types": ["jest", "node"]
+  }
+}


### PR DESCRIPTION
## Summary
- add `tsconfig.jest.json` extending app tsconfig
- update Jest config to use new TS config and ignore backend
- run frontend test suite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0a74075483309dbad0f0d7507f7b