### PR TITLE
chore: ignore env files and add example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Frontend
+VITE_API_URL=http://localhost:3001
+
+# Backend
+PORT=3001
+DATABASE_URL=postgres://usuario:senha@localhost:5432/scmg
+JWT_SECRET=sua_chave_secreta
+JWT_EXPIRES_IN=1d
+
+# Credenciais de admin (substitua em produção por variáveis seguras)
+ADMIN_EMAIL=admin@scmg.com.br
+ADMIN_PASSWORD=admin123
+
+# Origens permitidas para CORS
+ALLOWED_ORIGINS=https://scmg-feedback.onrender.com,http://localhost:3000

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,0 @@
-VITE_API_URL=https://scmg-backend.onrender.com

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,8 @@ coverage/
 backups/
 
 # Ambiente
-.env
-# .env.*
+.env*
+!**/.env.example
 
 # Sistema
 .DS_Store

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,0 @@
-VITE_API_URL=https://scmg-backend.onrender.com


### PR DESCRIPTION
## Summary
- remove tracked `.env.production`
- add `.env.example` with required variables
- ignore real env files in git

## Testing
- `npm test`
- `npm run lint` *(fails: 76 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0a79ad648330ad19f6473fc4eaa3