### PR TITLE
Remove logs de debug e padroniza erros de login

### DIFF
--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -45,12 +45,12 @@ export class AuthController {
       const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
       if (!user) {
         logger.info('Tentativa de login falhou', { email, ip, resultado: 'Usuário não encontrado' });
-        return res.status(400).json({ error: 'Usuário não encontrado' });
+        return res.status(400).json({ error: 'Credenciais inválidas' });
       }
       const isValidPassword = await user.checkPassword(password);
       if (!isValidPassword) {
         logger.info('Tentativa de login falhou', { email, ip, resultado: 'Senha inválida' });
-        return res.status(400).json({ error: 'Senha inválida' });
+        return res.status(400).json({ error: 'Credenciais inválidas' });
       }
       logger.info('Login realizado com sucesso', { email, ip, resultado: 'Sucesso', isAdmin: user.isAdmin });
       const signOptions: SignOptions = { expiresIn: env.JWT_EXPIRES_IN as any || '1d' };
@@ -65,7 +65,6 @@ export class AuthController {
         token,
       });
     } catch (error) {
-      console.log(error); // DEBUG: mostrar erro real nos testes
       logger.error('Erro interno ao tentar login', { email: req.body?.email, error });
       return res.status(500).json({ error: 'Erro interno do servidor' });
     }


### PR DESCRIPTION
## Summary
- Remover `console.log` do fluxo de login e registrar erros com `logger`
- Retornar mensagens genéricas de falha de autenticação

## Testing
- `npm test`
- `npm run lint` *(fails: no-undef, no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0a9e08808330b85b9a0b5f47d62e