### PR TITLE
Add validation error handling to feedback and suggestion routes

### DIFF
--- a/backend/__tests__/feedbackRoutes.test.ts
+++ b/backend/__tests__/feedbackRoutes.test.ts
@@ -19,9 +19,21 @@ describe('POST /api/feedback', () => {
   app.use(express.json());
   app.use('/api/feedback', feedbackRoutes);
 
-  it('returns 400 when fields are missing', async () => {
+  it('returns 422 when fields are missing', async () => {
     const res = await request(app).post('/api/feedback').send({});
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(422);
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'departmentId',
+          message: 'Departamento é obrigatório',
+        }),
+        expect.objectContaining({
+          field: 'rating',
+          message: 'Avaliação é obrigatória',
+        }),
+      ])
+    );
   });
 
   it('creates feedback when valid', async () => {

--- a/backend/src/routes/feedback.ts
+++ b/backend/src/routes/feedback.ts
@@ -1,7 +1,7 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { FeedbackController } from '../controllers/FeedbackController';
 import { authMiddleware, adminMiddleware } from '../middlewares/auth';
-import { body } from 'express-validator';
+import { body, validationResult } from 'express-validator';
 
 const router = Router();
 const feedbackController = new FeedbackController();
@@ -9,14 +9,38 @@ const feedbackController = new FeedbackController();
 router.post(
   '/',
   [
-    body('departmentId').isString().trim().escape().notEmpty().withMessage('Departamento é obrigatório'),
-    body('rating').isString().trim().escape().notEmpty().withMessage('Avaliação é obrigatória'),
+    body('departmentId')
+      .notEmpty()
+      .withMessage('Departamento é obrigatório')
+      .bail()
+      .isString()
+      .trim()
+      .escape(),
+    body('rating')
+      .notEmpty()
+      .withMessage('Avaliação é obrigatória')
+      .bail()
+      .isString()
+      .trim()
+      .escape(),
     body('suggestion').optional().isString().trim(),
     body('recomendacao')
       .optional()
       .isInt({ min: 0, max: 10 })
       .withMessage('Recomendação deve ser um número entre 0 e 10'),
   ],
+  (req: Request, res: Response, next: NextFunction) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({
+        errors: errors.array().map((error: any) => ({
+          field: error.path ?? error.param,
+          message: error.msg,
+        })),
+      });
+    }
+    next();
+  },
   feedbackController.create
 );
 router.get('/', authMiddleware, feedbackController.list);

--- a/backend/src/routes/suggestion.ts
+++ b/backend/src/routes/suggestion.ts
@@ -1,14 +1,34 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { SuggestionController } from '../controllers/SuggestionController';
 import { authMiddleware, adminMiddleware } from '../middlewares/auth';
-import { body } from 'express-validator';
+import { body, validationResult } from 'express-validator';
 
 const router = Router();
 const suggestionController = new SuggestionController();
 
 router.post(
   '/',
-  [body('suggestion').isString().trim().escape().notEmpty().withMessage('Sugestão é obrigatória')],
+  [
+    body('suggestion')
+      .notEmpty()
+      .withMessage('Sugestão é obrigatória')
+      .bail()
+      .isString()
+      .trim()
+      .escape(),
+  ],
+  (req: Request, res: Response, next: NextFunction) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({
+        errors: errors.array().map((error: any) => ({
+          field: error.path ?? error.param,
+          message: error.msg,
+        })),
+      });
+    }
+    next();
+  },
   suggestionController.create
 );
 router.get('/', authMiddleware, suggestionController.list);

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es2017",
     "module": "commonjs",
+    "moduleResolution": "node",
     "lib": ["es6"],
     "allowJs": true,
     "outDir": "./dist",


### PR DESCRIPTION
## Summary
- validate feedback input and return 422 with field messages
- validate suggestion input and return 422 with field messages
- test feedback route validation and configure TS to resolve express-validator

## Testing
- `cd backend && npx tsc -p tsconfig.json --noEmit`
- `cd backend && npm test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf0a969ff08330b90da36283e26cbb